### PR TITLE
Api/refresh token

### DIFF
--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -118,23 +118,26 @@ export class AuthController {
       if (!reqRefreshToken) return res.json(invalidTokenResponse);
 
       const accessTokenVerificationResult =
-        AuthService.verifyAccessToken(accessToken);
+        AuthService.verifyAccessToken(accessToken, true);
 
       if (!accessTokenVerificationResult.status)
         return res.json(invalidTokenResponse);
 
-      const accessTokenPayload: UserType = accessTokenVerificationResult.payload;
+      const accessTokenPayload: UserType =
+        accessTokenVerificationResult.payload;
 
-      const currentRefreshToken =
-        await RefreshTokenModel.getOneByUserIDAndToken(
+      const refreshTokenVerificationResult =
+        await AuthService.verifyRefreshToken(
           accessTokenPayload.user_id!,
           reqRefreshToken
         );
 
-      if (!currentRefreshToken)
+      if (!refreshTokenVerificationResult)
         return res.json(invalidTokenResponse);
 
-      const currentUser = await UserModel.getUserByID(accessTokenPayload.user_id!);
+      const currentUser = await UserModel.getUserByID(
+        accessTokenPayload.user_id!
+      );
 
       delete currentUser.password;
 
@@ -143,7 +146,7 @@ export class AuthController {
       return res.json({
         status: 200,
         message: "success",
-        token: newAccessToken
+        token: newAccessToken,
       });
     } catch (error) {
       console.error(error);

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -4,6 +4,9 @@ import { Validator } from "../helpers/validator";
 import { UserModel } from "../database/models/user";
 import { compare } from "bcrypt";
 import { AuthService } from "../services/auth";
+import { Utils } from "../helpers/utils";
+import { RefreshTokenModel } from "../database/models/refreshToken";
+import { UserType } from "../database/types/types";
 
 export class AuthController {
   public static async login(req: Request, res: Response) {
@@ -93,5 +96,61 @@ export class AuthController {
       message: "user successfully registered",
       token: accessToken,
     });
+  }
+
+  public static async refreshAccessToken(req: Request, res: Response) {
+    try {
+      const reqCookies = req.headers.cookie;
+      const accessToken = String(req.headers["x-access-token"]);
+
+      const invalidTokenResponse = {
+        status: 403,
+        message: "invalid token",
+      };
+
+      if (!reqCookies?.trim().replace(/ /g, ""))
+        return res.json(invalidTokenResponse);
+
+      if (!accessToken) return res.json(invalidTokenResponse);
+
+      const reqRefreshToken = Utils.parseCookie(reqCookies).rtoken;
+
+      if (!reqRefreshToken) return res.json(invalidTokenResponse);
+
+      const accessTokenVerificationResult =
+        AuthService.verifyAccessToken(accessToken);
+
+      if (!accessTokenVerificationResult.status)
+        return res.json(invalidTokenResponse);
+
+      const accessTokenPayload: UserType = accessTokenVerificationResult.payload;
+
+      const currentRefreshToken =
+        await RefreshTokenModel.getOneByUserIDAndToken(
+          accessTokenPayload.user_id!,
+          reqRefreshToken
+        );
+
+      if (!currentRefreshToken)
+        return res.json(invalidTokenResponse);
+
+      const currentUser = await UserModel.getUserByID(accessTokenPayload.user_id!);
+
+      delete currentUser.password;
+
+      const newAccessToken = AuthService.createAccessToken(currentUser);
+
+      return res.json({
+        status: 200,
+        message: "success",
+        token: newAccessToken
+      });
+    } catch (error) {
+      console.error(error);
+      return res.json({
+        status: 500,
+        message: "server error",
+      });
+    }
   }
 }

--- a/src/database/models/user.ts
+++ b/src/database/models/user.ts
@@ -38,4 +38,13 @@ export class UserModel {
 
     return user[0];
   }
+
+  public static async getUserByID(user_id: number): Promise<UserType> {
+    const user: UserType[] = await Database.query<UserType>(
+      "SELECT * FROM users WHERE user_id = $1",
+      [user_id]
+    );
+
+    return user[0];
+  }
 }

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -1,0 +1,15 @@
+export class Utils {
+  public static parseCookie(cookie: string) {
+    const cookiesObj: {[key: string]: string} = {};
+    const cookies = cookie.replace(/ /g, "").split(";");
+
+    cookies.forEach((element) => {
+      const splittedElement = element.split("=");
+      const key = splittedElement[0];
+      const value = splittedElement[1];
+      cookiesObj[key] = value;
+    });
+
+    return cookiesObj;
+  }
+}

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -5,3 +5,4 @@ export const authRouter = Router();
 
 authRouter.post("/login", AuthController.login);
 authRouter.post("/register", AuthController.register);
+authRouter.post("/refresh-token", AuthController.refreshAccessToken);

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -59,7 +59,7 @@ export class AuthService {
     return accessToken;
   }
 
-  public static verifyAccessToken(accessToken: string): {
+  public static verifyAccessToken(accessToken: string, ignoreExpiration = false): {
     status: boolean;
     payload: any;
   } {
@@ -67,6 +67,7 @@ export class AuthService {
       const jwtSecret = process.env.JWT_SECRET!;
       const payload = verify(accessToken, jwtSecret, {
         algorithms: ["HS256"],
+        ignoreExpiration
       });
       return {
         status: true,

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -61,7 +61,7 @@ export class AuthService {
 
   public static verifyAccessToken(accessToken: string): {
     status: boolean;
-    payload: JwtPayload | string;
+    payload: any;
   } {
     try {
       const jwtSecret = process.env.JWT_SECRET!;


### PR DESCRIPTION
- Add API /refresh-token
- Use the function verifyRefreshToken instead of duplicating the logic
- Ignore the expiration of jwt in case of the `refreshAccessToken` API